### PR TITLE
Add macOS DS_Store ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 **/obj
 **/bin
 **/.vs
+
+# macOS folder user view settings
+.DS_Store


### PR DESCRIPTION
(Proposing same PR in Meadow.Logging, Meadow.Units, and Meadow.Contracts.)

Might be worth using a more extensive Visual Studio-style .gitignore, but this will prevent any Mac folks from accidentally adding the OS-generated `.DS_Store` files.

We have something similar in [other](https://github.com/WildernessLabs/Meadow.Core.Samples/blob/5d4f16eb7599570ea6f163a64fc465dd3274fe7a/.gitignore#L332-L340) [repos](https://github.com/WildernessLabs/Meadow.Foundation/blob/e532eef01b71206038a0e8c4edfb6bf7afc7ef36/.gitignore#L257-L260), but I think this single-line version might be sufficient. (It's what they use in most of the [.gitignore samples](https://github.com/github/gitignore/search?q=.ds_store).