### PR TITLE
Add extension to calculate mean of IEnumerable<Speed>

### DIFF
--- a/Source/Meadow.Units/Extensions/SpeedExtensions.cs
+++ b/Source/Meadow.Units/Extensions/SpeedExtensions.cs
@@ -1,0 +1,20 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+
+namespace Meadow.Units;
+
+/// <summary>
+/// Provides extension methods for creating <see cref="Speed"/> instances.
+/// </summary>
+public static class SpeedExtensions
+{
+    /// <summary>
+    /// calculates a mean Speed
+    /// </summary>
+    /// <param name="samples"></param>
+    /// <returns></returns>
+    public static Speed Mean(this IEnumerable<Speed> samples)
+    {
+        return new Speed(samples.Select(a => a.KilometersPerSecond).Average(), Speed.UnitType.KilometersPerSecond);
+    }
+}


### PR DESCRIPTION
Clima needs to report the sampled speed of the wind and the average speed. see [PR 78](https://github.com/WildernessLabs/Clima/issues/78)

Replicates the approach used in AzimuthExtensions that uses **Linq**. 
This may be inefficient (speed and user more memory) than a `for` loop. 