### PR TITLE
fix: correct dead Value field in four unit types and two conversion bugs

### DIFF
--- a/Source/Meadow.Units/Charge.cs
+++ b/Source/Meadow.Units/Charge.cs
@@ -24,7 +24,7 @@ public partial struct Charge :
     /// <param name="type">Coulombs by default.</param>
     public Charge(double value, UnitType type = UnitType.Coulombs)
     {
-        Coulombs = value;
+        Value = value;
     }
 
     /// <summary>
@@ -33,7 +33,7 @@ public partial struct Charge :
     /// <param name="Charge"></param>
     public Charge(Charge Charge)
     {
-        Coulombs = Charge.Coulombs;
+        Value = Charge.Value;
     }
 
     /// <summary>
@@ -44,7 +44,7 @@ public partial struct Charge :
     /// <summary>
     /// The Charge in coulombs
     /// </summary>
-    public double Coulombs { get; private set; }
+    public double Coulombs => Value;
 
     /// <summary>
     /// The type of units available to describe the Charge.

--- a/Source/Meadow.Units/Conversions/AzimuthConversions.cs
+++ b/Source/Meadow.Units/Conversions/AzimuthConversions.cs
@@ -61,7 +61,7 @@ public static class AzimuthConversions
 
         return value switch
         {
-            double v when (v >= 348.75f && v < 11.25) => Azimuth16PointCardinalNames.N,
+            double v when (v >= 348.75 || v < 11.25) => Azimuth16PointCardinalNames.N,
             double v when (v >= 11.25f && v < 33.75) => Azimuth16PointCardinalNames.NNE,
             double v when (v >= 33.75f && v < 56.25) => Azimuth16PointCardinalNames.NE,
             double v when (v >= 56.25f && v < 78.75) => Azimuth16PointCardinalNames.ENE,

--- a/Source/Meadow.Units/Conversions/PowerConversions.cs
+++ b/Source/Meadow.Units/Conversions/PowerConversions.cs
@@ -15,7 +15,7 @@ internal static class PowerConversions
     private static readonly double[] powerConversions =
     {
         0.000000001,        //gigawatts
-        0.000001,           //milliwatts
+        0.000001,           //megawatts
         0.001,              //kwatts
         1.0,                //watts
         1000.0,             //milliwatt

--- a/Source/Meadow.Units/PotentialHydrogen.cs
+++ b/Source/Meadow.Units/PotentialHydrogen.cs
@@ -41,7 +41,7 @@ public partial struct PotentialHydrogen :
     /// <param name="type">Potential Hydrogen unit.</param>
     public PotentialHydrogen(double value, UnitType type = UnitType.pH)
     {
-        pH = value;
+        Value = value;
     }
 
     /// <summary>
@@ -50,13 +50,13 @@ public partial struct PotentialHydrogen :
     /// <param name="PotentialHydrogen"></param>
     public PotentialHydrogen(PotentialHydrogen PotentialHydrogen)
     {
-        pH = PotentialHydrogen.pH;
+        Value = PotentialHydrogen.Value;
     }
 
     /// <summary>
     /// The Potential Hydrogen expressed as pH.
     /// </summary>
-    public double pH { get; private set; }
+    public double pH => Value;
 
     /// <summary>
     /// The type of units available to describe the PotentialHydrogen.

--- a/Source/Meadow.Units/RelativeHumidity.cs
+++ b/Source/Meadow.Units/RelativeHumidity.cs
@@ -26,7 +26,7 @@ public partial struct RelativeHumidity :
     /// <param name="type">Relative humidity unit.</param>
     public RelativeHumidity(double value, UnitType type = UnitType.Percent)
     {
-        Percent = value;
+        Value = value;
     }
 
     /// <summary>
@@ -35,7 +35,7 @@ public partial struct RelativeHumidity :
     /// <param name="relativeHumidity"></param>
     public RelativeHumidity(RelativeHumidity relativeHumidity)
     {
-        Percent = relativeHumidity.Percent;
+        Value = relativeHumidity.Value;
     }
 
     /// <summary>
@@ -46,7 +46,7 @@ public partial struct RelativeHumidity :
     /// <summary>
     /// The relative expressed as a value percent.
     /// </summary>
-    public double Percent { get; private set; }
+    public double Percent => Value;
     /// <summary>
     /// The type of units available to describe the RelativeHumidity.
     /// </summary>

--- a/Source/Meadow.Units/Turbidity.cs
+++ b/Source/Meadow.Units/Turbidity.cs
@@ -25,7 +25,7 @@ public partial struct Turbidity :
     public Turbidity(double value, UnitType type = UnitType.NTU)
     {
         if (value < 0) throw new ArgumentOutOfRangeException($"Turbidity cannot be less than 0");
-        NTU = value;
+        Value = value;
     }
 
     /// <summary>
@@ -34,7 +34,7 @@ public partial struct Turbidity :
     /// <param name="Turbidity"></param>
     public Turbidity(Turbidity Turbidity)
     {
-        NTU = Turbidity.NTU;
+        Value = Turbidity.Value;
     }
 
     /// <summary>
@@ -45,7 +45,7 @@ public partial struct Turbidity :
     /// <summary>
     /// The Turbidity expressed as Nephelometric Turbidity Units (NTU)
     /// </summary>
-    public double NTU { get; private set; }
+    public double NTU => Value;
 
     /// <summary>
     /// The type of units available to describe the Turbidity.


### PR DESCRIPTION
- Charge, PotentialHydrogen, RelativeHumidity, Turbidity: constructors were assigning to the named auto-property instead of the backing `Value` field. The source generator targets `Value` for all arithmetic and comparison operators, so every +, -, *, /, ==, != and CompareTo operated on 0.0. Fixed by assigning `Value` in constructors and converting the named properties to computed expressions (`=> Value`).

- AzimuthConversions.DegressToCompass16PointCardinalName: the North case used `&&` (v >= 348.75 && v < 11.25) which is an impossible predicate — North was only ever returned via the fallback `_`. Fixed to `||`.

- PowerConversions: index-1 comment said "milliwatts" but the value (0.000001) corresponds to megawatts. Corrected to "megawatts".